### PR TITLE
fix(cache on ratings by account): the cache on the ratings by account…

### DIFF
--- a/src/modules/account/models/interfaces/ratings-by-account.ts
+++ b/src/modules/account/models/interfaces/ratings-by-account.ts
@@ -1,0 +1,9 @@
+export interface RatingsByAccount {
+    rating: number;
+    commentary: string;
+    toMovie: {
+        tmdbId: number;
+        posterPath: string;
+        title: string;
+    };
+}

--- a/src/modules/ratings/ratings.service.ts
+++ b/src/modules/ratings/ratings.service.ts
@@ -172,11 +172,24 @@ export class RatingsService {
 
         // update cache
         const ratingByMovieKey = `${CachePrefixes.RatingsByMovieCached}-${data.tmdbId}`;
-        await this.updateCache<RatingsByMovie>(ratingByMovieKey, ratingCreated);
+        const ratingByMovieCachedData =
+            ((await this.cacheManager.get(
+                ratingByMovieKey,
+            )) as RatingsByMovie[]) || [];
+        await this.cacheManager.set(ratingByMovieKey, [
+            ...ratingByMovieCachedData,
+            ratingCreated,
+        ]);
 
         // update accounts by rating cache
         const accountKey = `${CachePrefixes.AccountIdentifierCached}-${userId}-ratings`;
-        await this.updateCache<RatingsByAccount>(accountKey, ratingCreated);
+        const accountCachedData =
+            ((await this.cacheManager.get(accountKey)) as RatingsByAccount[]) ||
+            [];
+        await this.cacheManager.set(accountKey, [
+            ...accountCachedData,
+            ratingCreated,
+        ]);
 
         return ratingCreated;
     }

--- a/src/modules/ratings/ratings.service.ts
+++ b/src/modules/ratings/ratings.service.ts
@@ -172,24 +172,11 @@ export class RatingsService {
 
         // update cache
         const ratingByMovieKey = `${CachePrefixes.RatingsByMovieCached}-${data.tmdbId}`;
-        const ratingByMovieCachedData =
-            ((await this.cacheManager.get(
-                ratingByMovieKey,
-            )) as RatingsByMovie[]) || [];
-        await this.cacheManager.set(ratingByMovieKey, [
-            ...ratingByMovieCachedData,
-            ratingCreated,
-        ]);
+        await this.updateCache<RatingsByMovie>(ratingByMovieKey, ratingCreated);
 
         // update accounts by rating cache
         const accountKey = `${CachePrefixes.AccountIdentifierCached}-${userId}-ratings`;
-        const accountCachedData =
-            ((await this.cacheManager.get(accountKey)) as RatingsByAccount[]) ||
-            [];
-        await this.cacheManager.set(accountKey, [
-            ...accountCachedData,
-            ratingCreated,
-        ]);
+        await this.updateCache<RatingsByAccount>(accountKey, ratingCreated);
 
         return ratingCreated;
     }


### PR DESCRIPTION
… wasn't updaiting data

The cache, on the ratings by account wasn't updating data on deletion or addition. This meant that there was a stale state on ratings by account which could potentially downgrade the user experience