### PR TITLE
refactor(throttler): changed throttler defaults

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -36,11 +36,11 @@ import { ProfilesModule } from './modules/profiles/profiles.module';
         ConfigModule.forRoot({ isGlobal: true }),
         ThrottlerModule.forRoot({
             throttlers: [
-                {
-                    name: 'short',
-                    ttl: 1000,
-                    limit: 3,
-                },
+                // {
+                //     name: 'short',
+                //     ttl: 1000,
+                //     limit: 3,
+                // },
                 {
                     name: 'medium',
                     ttl: 10000,


### PR DESCRIPTION
Normal user was shot with a 429 HTTP error when he made to many requests, that was because the application had a short throttling configuration. For the moment i leave the medium and long configurations but it requires deep tweaking